### PR TITLE
Diagram Template - Changed syntaxId to plain/1.0

### DIFF
--- a/src/main/resources/Diagram/DiagramTemplate.xml
+++ b/src/main/resources/Diagram/DiagramTemplate.xml
@@ -40,7 +40,7 @@
   <validationScript/>
   <comment/>
   <minorEdit>false</minorEdit>
-  <syntaxId>xwiki/2.1</syntaxId>
+  <syntaxId>plain/1.0</syntaxId>
   <hidden>true</hidden>
   <content/>
   <object>


### PR DESCRIPTION
This was changed to stop links normalising to xwiki 2.1 syntax.

See https://jira.xwiki.org/browse/XADIAGRAM-52